### PR TITLE
Support for Dimensional Tears

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,8 @@ configurations {
 
 dependencies {
     implementation("com.teamabnormals:blueprint:$minecraft_version-$blueprint_version")
-    compileOnly("maven.modrinth:spelunkery:v6sHcul7")
+    implementation("maven.modrinth:dimensional-tears:fsDhzOba")
+    implementation("maven.modrinth:moonlight:QiGuwr5v")
 
     compileOnly("mezz.jei:jei-${minecraft_version}-neoforge-api:${jei}")
     runtimeOnly("mezz.jei:jei-${minecraft_version}-neoforge:${jei}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ parchment_minecraft_version=1.21.1
 parchment_mappings_version=2024.11.17
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1]
-neo_version=21.1.171
+neo_version=21.1.224
 neo_version_range=[21.1.171,)
 loader_version_range=[1,)

--- a/src/main/java/com/davigj/frame_changer/core/FrameChanger.java
+++ b/src/main/java/com/davigj/frame_changer/core/FrameChanger.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.davigj.frame_changer.core.other.FCConstants.*;
 import static com.davigj.frame_changer.core.other.FCDataMapUtil.CRYING_CONVERTS;
-import static com.davigj.frame_changer.core.other.FCDataMapUtil.SPELUNKERY_PORTAL_FLUID_DRAIN_CONVERTS;
+import static com.davigj.frame_changer.core.other.FCDataMapUtil.DIMENSIONAL_TEARS_DIMENSIONAL_TEARS_DRAIN_CONVERTS;
 
 @Mod(FrameChanger.MOD_ID)
 public class FrameChanger {
@@ -83,6 +83,6 @@ public class FrameChanger {
     @SubscribeEvent
     private void registerDataMapTypes(RegisterDataMapTypesEvent event) {
         event.register(CRYING_CONVERTS);
-        event.register(SPELUNKERY_PORTAL_FLUID_DRAIN_CONVERTS);
+        event.register(DIMENSIONAL_TEARS_DIMENSIONAL_TEARS_DRAIN_CONVERTS);
     }
 }

--- a/src/main/java/com/davigj/frame_changer/core/mixin/NetherPortalBlockMixin.java
+++ b/src/main/java/com/davigj/frame_changer/core/mixin/NetherPortalBlockMixin.java
@@ -14,15 +14,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.davigj.frame_changer.core.other.FCConstants.spelunkeryCryingPortals;
+import static com.davigj.frame_changer.core.other.FCConstants.dimensionalTearsCryingPortals;
 
 @Mixin(NetherPortalBlock.class)
 public class NetherPortalBlockMixin {
     @Inject(method = "updateShape", at = @At("HEAD"))
     private void updateObby(BlockState state, Direction dir, BlockState nextState, LevelAccessor level, BlockPos pos, BlockPos nextPos, CallbackInfoReturnable<BlockState> cir) {
         if (!level.isClientSide()) {
-            if (ModList.get().isLoaded("spelunkery")) {
-                if (spelunkeryCryingPortals) {
+            if (ModList.get().isLoaded("dimensional_tears")) {
+                if (dimensionalTearsCryingPortals <= 0 && level.getRandom().nextDouble() <= dimensionalTearsCryingPortals) {
                     FCDataMapUtil.fluidSpread(state, (Level) level, pos, 0.33D);
                 }
             } else if (FCConfig.COMMON.contagiousMisery.get()) {

--- a/src/main/java/com/davigj/frame_changer/core/other/FCConstants.java
+++ b/src/main/java/com/davigj/frame_changer/core/other/FCConstants.java
@@ -1,9 +1,8 @@
 package com.davigj.frame_changer.core.other;
 
 import com.davigj.frame_changer.core.registry.FCBlocks;
-import com.ordana.spelunkery.configs.CommonConfigs;
+import com.ordana.dimensional_tears.configs.CommonConfigs;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.neoforged.fml.ModList;
 
 import java.util.HashMap;
@@ -11,8 +10,8 @@ import java.util.Map;
 
 public class FCConstants {
     public static final Map<Block, Block> CHISEL_MAP = new HashMap<>();
-    public static final boolean spelunkeryCryingPortals;
-    public static final boolean spelunkeryPortalFluid;
+    public static final double dimensionalTearsCryingPortals;
+    public static final boolean dimensionalTearsPortalFluid;
 
     public static void determineChiselMap() {
         CHISEL_MAP.put(FCBlocks.OBSIDIAN_BRICKS.get(), FCBlocks.CHISELED_OBSIDIAN.get());
@@ -20,7 +19,7 @@ public class FCConstants {
     }
 
     static {
-        spelunkeryCryingPortals = ModList.get().isLoaded("spelunkery") ? CommonConfigs.PORTAL_DESTRUCTION_CRYING_OBSIDIAN.get() : false;
-        spelunkeryPortalFluid = ModList.get().isLoaded("spelunkery") ? CommonConfigs.CRYING_OBSIDIAN_PORTAL_FLUID.get() : false;
+        dimensionalTearsCryingPortals = ModList.get().isLoaded("dimensional_tears") ? CommonConfigs.PORTAL_DESTRUCTION_CRYING_OBSIDIAN_CHANCE.get() : 0;
+        dimensionalTearsPortalFluid = ModList.get().isLoaded("dimensional_tears") ? CommonConfigs.CRYING_OBSIDIAN_DIMENSIONAL_TEARS.get() : false;
     }
 }

--- a/src/main/java/com/davigj/frame_changer/core/other/FCDataMapUtil.java
+++ b/src/main/java/com/davigj/frame_changer/core/other/FCDataMapUtil.java
@@ -3,7 +3,7 @@ package com.davigj.frame_changer.core.other;
 import com.davigj.frame_changer.core.FrameChanger;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.ordana.spelunkery.reg.ModItems;
+import com.ordana.dimensional_tears.reg.ModItems;
 import com.teamabnormals.blueprint.core.util.BlockUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -32,11 +32,10 @@ import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.spongepowered.asm.mixin.Unique;
 
 import java.util.function.Supplier;
 
-import static com.davigj.frame_changer.core.other.FCConstants.spelunkeryCryingPortals;
+import static com.davigj.frame_changer.core.other.FCConstants.dimensionalTearsCryingPortals;
 
 public class FCDataMapUtil {
     private final static Logger LOGGER = LogManager.getLogger(FrameChanger.MOD_ID);
@@ -51,8 +50,8 @@ public class FCDataMapUtil {
             ResourceLocation.fromNamespaceAndPath(FrameChanger.MOD_ID, "crying_converts"), Registries.BLOCK, CryingData.CODEC
     ).build();
 
-    public static final DataMapType<Block, CryingData> SPELUNKERY_PORTAL_FLUID_DRAIN_CONVERTS = DataMapType.builder(
-            ResourceLocation.fromNamespaceAndPath(FrameChanger.MOD_ID, "spelunkery_portal_fluid_drain_converts"), Registries.BLOCK, CryingData.CODEC
+    public static final DataMapType<Block, CryingData> DIMENSIONAL_TEARS_DIMENSIONAL_TEARS_DRAIN_CONVERTS = DataMapType.builder(
+            ResourceLocation.fromNamespaceAndPath(FrameChanger.MOD_ID, "dimensional_tears_dimensional_tears_drain_converts"), Registries.BLOCK, CryingData.CODEC
     ).build();
 
     private static Supplier<Block> getConversionBlock(String fullId) {
@@ -86,8 +85,8 @@ public class FCDataMapUtil {
 
             if (data != null && random.nextDouble() < cryChance && !(new PortalShape(level, pos, axis2)).isComplete()) {
                 BlockState convertedState = BlockUtil.transferAllBlockStates(cryState, getConversionBlock(data.result).get().defaultBlockState());
-                if (ModList.get().isLoaded("spelunkery")) {
-                    if (!(spelunkeryCryingPortals && cryState.is(Blocks.OBSIDIAN))) {
+                if (ModList.get().isLoaded("dimensional_tears")) {
+                    if (!(dimensionalTearsCryingPortals <= 0 && level.getRandom().nextDouble() <= dimensionalTearsCryingPortals && cryState.is(Blocks.OBSIDIAN))) {
                         level.setBlock(pos.relative(cryDir), convertedState, 3);
                     }
                 } else {
@@ -99,14 +98,14 @@ public class FCDataMapUtil {
 
     public static void fluidDrain(Player player, BlockState clickedBlockState, ItemStack heldItem, PlayerInteractEvent.RightClickBlock event) {
         Holder<Block> holder = clickedBlockState.getBlockHolder();
-        FCDataMapUtil.CryingData data = holder.getData(SPELUNKERY_PORTAL_FLUID_DRAIN_CONVERTS);
+        FCDataMapUtil.CryingData data = holder.getData(DIMENSIONAL_TEARS_DIMENSIONAL_TEARS_DRAIN_CONVERTS);
 
         if (data != null && heldItem.is(Items.GLASS_BOTTLE)) {
             BlockState convertedState = BlockUtil.transferAllBlockStates(clickedBlockState, getConversionBlock(data.result).get().defaultBlockState());
             player.level().setBlock(event.getPos(), convertedState, 3);
             player.swing(event.getHand());
             event.setCancellationResult(InteractionResult.SUCCESS);
-            ItemStack portalFluid = new ItemStack(ModItems.PORTAL_FLUID_BOTTLE.get());
+            ItemStack portalFluid = new ItemStack(ModItems.DIMENSIONAL_TEARS_BOTTLE.get());
             player.level().playSound(player, event.getPos(), SoundEvents.RESPAWN_ANCHOR_DEPLETE.value(), SoundSource.BLOCKS, 1.0f, 1.0f);
             ParticleUtils.spawnParticlesOnBlockFaces(player.level(), event.getPos(), ParticleTypes.FALLING_OBSIDIAN_TEAR, UniformInt.of(3, 5));
             if (!player.getAbilities().instabuild) {

--- a/src/main/java/com/davigj/frame_changer/core/other/FCEvents.java
+++ b/src/main/java/com/davigj/frame_changer/core/other/FCEvents.java
@@ -13,7 +13,7 @@ import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 public class FCEvents {
     @SubscribeEvent
     public static void onPlayerRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (!ModList.get().isLoaded("spelunkery") || !FCConstants.spelunkeryPortalFluid) {
+        if (!ModList.get().isLoaded("dimensional_tears") || !FCConstants.dimensionalTearsPortalFluid) {
             return;
         }
         Player player = event.getEntity();

--- a/src/main/resources/data/frame_changer/recipe/emptying/chiseled_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/emptying/chiseled_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -20,7 +20,7 @@
       "item": "frame_changer:chiseled_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ]

--- a/src/main/resources/data/frame_changer/recipe/emptying/obsidian_bricks.json
+++ b/src/main/resources/data/frame_changer/recipe/emptying/obsidian_bricks.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -20,7 +20,7 @@
       "item": "frame_changer:obsidian_bricks"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ]

--- a/src/main/resources/data/frame_changer/recipe/emptying/obsidian_pillar.json
+++ b/src/main/resources/data/frame_changer/recipe/emptying/obsidian_pillar.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -20,7 +20,7 @@
       "item": "frame_changer:obsidian_pillar"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ]

--- a/src/main/resources/data/frame_changer/recipe/emptying/polished_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/emptying/polished_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -20,7 +20,7 @@
       "item": "frame_changer:polished_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ]

--- a/src/main/resources/data/frame_changer/recipe/filling/crying_chiseled_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/filling/crying_chiseled_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -15,7 +15,7 @@
       "item": "frame_changer:chiseled_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ],

--- a/src/main/resources/data/frame_changer/recipe/filling/crying_obsidian_bricks.json
+++ b/src/main/resources/data/frame_changer/recipe/filling/crying_obsidian_bricks.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -15,7 +15,7 @@
       "item": "frame_changer:obsidian_bricks"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ],

--- a/src/main/resources/data/frame_changer/recipe/filling/crying_obsidian_pillar.json
+++ b/src/main/resources/data/frame_changer/recipe/filling/crying_obsidian_pillar.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -15,7 +15,7 @@
       "item": "frame_changer:obsidian_pillar"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ],

--- a/src/main/resources/data/frame_changer/recipe/filling/crying_polished_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/filling/crying_polished_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -15,7 +15,7 @@
       "item": "frame_changer:polished_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "amount": 250
     }
   ],

--- a/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_chiseled_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_chiseled_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -23,7 +23,7 @@
       "item": "frame_changer:chiseled_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "nbt": {},
       "amount": 250
     }

--- a/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_obsidian_bricks.json
+++ b/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_obsidian_bricks.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -23,7 +23,7 @@
       "item": "frame_changer:obsidian_bricks"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "nbt": {},
       "amount": 250
     }

--- a/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_obsidian_pillar.json
+++ b/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_obsidian_pillar.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -23,7 +23,7 @@
       "item": "frame_changer:obsidian_pillar"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "nbt": {},
       "amount": 250
     }

--- a/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_polished_obsidian.json
+++ b/src/main/resources/data/frame_changer/recipe/mixing/portal_fluid_from_crying_polished_obsidian.json
@@ -5,7 +5,7 @@
       "type": "neoforge:mod_loaded"
     },
     {
-      "modid": "spelunkery",
+      "modid": "dimensional_tears",
       "type": "neoforge:mod_loaded"
     }
   ],
@@ -23,7 +23,7 @@
       "item": "frame_changer:polished_obsidian"
     },
     {
-      "fluid": "spelunkery:portal_fluid",
+      "fluid": "dimensional_tears:dimensional_tears",
       "nbt": {},
       "amount": 250
     }


### PR DESCRIPTION
Spelunkery has split Dimensional Tears into its own mod. Attempting to use Frame Changer with the (currently unreleased) 1.21.1 version of Spelunkery will crash the game. This PR updates the Dimensional Tears integration to use the standalone mod.